### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## FAQ
 Q: What versions does this plugin support?
 
-A: 1.21, 1.21.1, 1.21.2, 1.21.3
+A: 1.21, 1.21.1, 1.21.2, 1.21.3, and 1.21.4
 
 Q: Are there any plans to support any other versions?
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.github.lukesky19"
-version = "1.0.0"
+version = "1.1.0"
 
 repositories {
     mavenCentral()
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
     compileOnly("net.kyori:adventure-api:4.17.0")
     compileOnly("net.kyori:adventure-text-minimessage:4.17.0")
     compileOnly("me.clip:placeholderapi:2.11.6")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
-    compileOnly("net.kyori:adventure-api:4.17.0")
-    compileOnly("net.kyori:adventure-text-minimessage:4.17.0")
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
     implementation("org.spongepowered:configurate-yaml:4.1.2")
     implementation("org.bstats:bstats-bukkit:3.0.2")

--- a/src/main/java/com/github/lukesky19/skylib/SkyLib.java
+++ b/src/main/java/com/github/lukesky19/skylib/SkyLib.java
@@ -17,6 +17,7 @@
 */
 package com.github.lukesky19.skylib;
 
+import com.github.lukesky19.skylib.listener.LoginListener;
 import com.github.lukesky19.skylib.version.VersionUtil;
 import io.papermc.paper.ServerBuildInfo;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -41,5 +42,7 @@ public final class SkyLib extends JavaPlugin {
         // Store Minecraft Major and Minor Versions
         VersionUtil.setMajorVersion(Integer.parseInt(splitVersion[1]));
         VersionUtil.setMinorVersion(Integer.parseInt(splitVersion[2]));
+
+        this.getServer().getPluginManager().registerEvents(new LoginListener(), this);
     }
 }

--- a/src/main/java/com/github/lukesky19/skylib/SkyLib.java
+++ b/src/main/java/com/github/lukesky19/skylib/SkyLib.java
@@ -17,9 +17,29 @@
 */
 package com.github.lukesky19.skylib;
 
+import com.github.lukesky19.skylib.version.VersionUtil;
+import io.papermc.paper.ServerBuildInfo;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Entry point to the plugin.
  */
-public final class SkyLib extends JavaPlugin {}
+public final class SkyLib extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        // Get ServerBuildInfo and Minecraft version
+        final ServerBuildInfo build = ServerBuildInfo.buildInfo();
+        final String minecraftVersionId = build.minecraftVersionId();
+
+        // Store Minecraft Version
+        VersionUtil.setMinecraftVersion(minecraftVersionId);
+
+        // Parse Minecraft Version for major and minor
+        final @NotNull String[] splitVersion = minecraftVersionId.split("\\.");
+
+        // Store Minecraft Major and Minor Versions
+        VersionUtil.setMajorVersion(Integer.parseInt(splitVersion[1]));
+        VersionUtil.setMinorVersion(Integer.parseInt(splitVersion[2]));
+    }
+}

--- a/src/main/java/com/github/lukesky19/skylib/format/FormatUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/format/FormatUtil.java
@@ -17,6 +17,7 @@
 */
 package com.github.lukesky19.skylib.format;
 
+import com.github.lukesky19.skylib.record.Time;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -210,57 +211,6 @@ public class FormatUtil {
     }
 
     /**
-     * Takes milliseconds and converts it to years, months, weeks, days, hours, minutes, and seconds.
-     * @param millis The Milliseconds to parse
-     * @return A String
-     */
-    public static String millisToString(long millis) {
-        long y = 0;
-        long M = 0;
-        long w = 0;
-        long d = 0;
-        long h = 0;
-        long m = 0;
-        long s = 0;
-
-        if(millis >= YEAR) {
-            y = millis / YEAR;
-            millis %= YEAR;
-        }
-
-        if(millis >= MONTH) {
-            M = millis / MONTH;
-            millis %= MONTH;
-        }
-
-        if(millis >= WEEK) {
-            w = millis / WEEK;
-            millis %= WEEK;
-        }
-
-        if(millis >= DAY) {
-            d = millis / DAY;
-            millis %= DAY;
-        }
-
-        if(millis >= HOUR) {
-            h = millis / HOUR;
-            millis %= HOUR;
-        }
-
-        if(millis >= MINUTE) {
-            m = millis / MINUTE;
-            millis %= MINUTE;
-        }
-
-        if(millis >= SECOND) {
-            s = millis / SECOND;
-        }
-
-        return y + " years " + M + " months " + w + " weeks " + d + " days " + h + " hours " + m + " minutes " + s + " seconds";
-    }
-
-    /**
      * Takes String representing an amount of time (i.e., 1d2h30m) and converts it to Milliseconds.
      * @param time A String with a time to parse
      * @return Milliseconds
@@ -288,6 +238,73 @@ public class FormatUtil {
                 case "y" -> millis = (num * 365L * 24L * 60L * 60L * 1000L) + millis;
             }
         }
+
+        return millis;
+    }
+
+    /**
+     * Takes a long representing milliseconds and returns a {@link Time} Record that holds the years, months, weeks, days, hours, minutes, and milliseconds.
+     * @param millis The milliseconds to convert.
+     * @return A {@link Time} Record that holds the years, months, weeks, days, hours, minutes, and milliseconds.
+     */
+    public static Time millisToTime(long millis) {
+        int years = 0;
+        int months = 0;
+        int weeks = 0;
+        int days = 0;
+        int hours = 0;
+        int minutes = 0;
+        int seconds = 0;
+
+        if(millis >= YEAR) {
+            years = (int) (millis / YEAR);
+            millis %= YEAR;
+        }
+
+        if(millis >= MONTH) {
+            months = (int) (millis / MONTH);
+            millis %= MONTH;
+        }
+
+        if(millis >= WEEK) {
+            weeks = (int) (millis / WEEK);
+            millis %= WEEK;
+        }
+
+        if(millis >= DAY) {
+            days = (int) (millis / DAY);
+            millis %= DAY;
+        }
+
+        if(millis >= HOUR) {
+            hours = (int) (millis / HOUR);
+            millis %= HOUR;
+        }
+
+        if(millis >= MINUTE) {
+            minutes = (int) (millis / MINUTE);
+            millis %= MINUTE;
+        }
+
+        if(millis >= SECOND) {
+            seconds = (int) (millis / SECOND);
+            millis %= SECOND;
+        }
+
+        return new Time(years, months, weeks, days, hours, minutes, seconds, (int) millis);
+    }
+
+    public static long timeToMillis(@NotNull Time time) {
+        long millis = 0;
+
+        millis += time.years() * YEAR;
+        millis += time.months() * MONTH;
+        millis += time.weeks() * WEEK;
+        millis += time.days() * DAY;
+        millis += time.hours() * HOUR;
+        millis += time.minutes() * MINUTE;
+        millis += time.seconds() * SECOND;
+        millis += time.milliseconds();
 
         return millis;
     }

--- a/src/main/java/com/github/lukesky19/skylib/format/FormatUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/format/FormatUtil.java
@@ -294,6 +294,11 @@ public class FormatUtil {
         return new Time(years, months, weeks, days, hours, minutes, seconds, (int) millis);
     }
 
+    /**
+     * Converts a {@link Time} Record to milliseconds.
+     * @param time A {@link Time} Record
+     * @return A long representing the milliseconds.
+     */
     public static long timeToMillis(@NotNull Time time) {
         long millis = 0;
 

--- a/src/main/java/com/github/lukesky19/skylib/gui/GUIButton.java
+++ b/src/main/java/com/github/lukesky19/skylib/gui/GUIButton.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import com.destroystokyo.paper.profile.PlayerProfile;
 import com.github.lukesky19.skylib.version.VersionUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
@@ -30,6 +31,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckForNull;
@@ -70,7 +72,7 @@ public class GUIButton {
         if(builder.material == null) throw new RuntimeException("Material is required to build the button.");
 
         final ItemStack builtStack = new ItemStack(builder.material);
-        final ItemMeta itemMeta = builtStack.getItemMeta();
+        ItemMeta itemMeta = builtStack.getItemMeta();
 
         // Set the item name.
         if(builder.name != null) itemMeta.displayName(builder.name);
@@ -84,6 +86,14 @@ public class GUIButton {
         // Set the item model
         if(builder.model != null) {
             itemMeta.setItemModel(builder.model);
+        }
+
+        // Set the PlayerProfile of a skull if the material matches PLAYER_HEAD.
+        if(builder.material == Material.PLAYER_HEAD) {
+            if (builder.playerProfile != null) {
+                SkullMeta skullMeta = (SkullMeta) itemMeta;
+                skullMeta.setPlayerProfile(builder.playerProfile);
+            }
         }
 
         // Set the ItemStack's ItemMeta
@@ -109,6 +119,7 @@ public class GUIButton {
         @NotNull private List<Component> lore = new ArrayList<>();
         @NotNull private List<ItemFlag> itemFlags = new ArrayList<>();
         @CheckForNull private NamespacedKey model;
+        @CheckForNull PlayerProfile playerProfile;
         @CheckForNull private Consumer<InventoryClickEvent> action;
 
         /**
@@ -173,6 +184,16 @@ public class GUIButton {
             }
 
             throw new RuntimeException("Item Models are only available on Minecraft 1.21.3 and newer.");
+        }
+
+        /**
+         * Sets the PlayerProfile if the Material is that of a PLAYER_HEAD
+         * @param playerProfile A PlayerProfile of an online player.
+         * @return A GUIButton Builder.
+         */
+        public Builder setPlayerProfile(@NotNull PlayerProfile playerProfile) {
+            this.playerProfile = playerProfile;
+            return this;
         }
 
         /**

--- a/src/main/java/com/github/lukesky19/skylib/gui/InventoryGUI.java
+++ b/src/main/java/com/github/lukesky19/skylib/gui/InventoryGUI.java
@@ -65,7 +65,7 @@ public class InventoryGUI implements InventoryHolder, GUIInterface {
 
     @Override
     public void createInventory(int size, @NotNull String title) {
-        Bukkit.createInventory(null, size, FormatUtil.format(title));
+        inventory = Bukkit.createInventory(this, size, FormatUtil.format(title));
     }
 
     @Override

--- a/src/main/java/com/github/lukesky19/skylib/gui/InventoryGUI.java
+++ b/src/main/java/com/github/lukesky19/skylib/gui/InventoryGUI.java
@@ -27,8 +27,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -72,14 +70,7 @@ public class InventoryGUI implements InventoryHolder, GUIInterface {
 
     @Override
     public void decorate() {
-        this.buttonMap.forEach((slot, button) -> {
-            ItemStack icon = button.itemStack();
-            ItemMeta iconMeta = icon.getItemMeta();
-            iconMeta.displayName(button.itemName());
-            iconMeta.lore(button.lore());
-            icon.setItemMeta(iconMeta);
-            inventory.setItem(slot, icon);
-        });
+        this.buttonMap.forEach((slot, button) -> inventory.setItem(slot, button.itemStack()));
     }
 
     @Override

--- a/src/main/java/com/github/lukesky19/skylib/listener/LoginListener.java
+++ b/src/main/java/com/github/lukesky19/skylib/listener/LoginListener.java
@@ -1,0 +1,14 @@
+package com.github.lukesky19.skylib.listener;
+
+import com.github.lukesky19.skylib.player.PlayerUtil;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class LoginListener implements Listener {
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onJoin(PlayerJoinEvent event) {
+        PlayerUtil.cachePlayerProfile(event.getPlayer().getUniqueId(), event.getPlayer().getPlayerProfile());
+    }
+}

--- a/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
@@ -1,16 +1,55 @@
 package com.github.lukesky19.skylib.player;
 
+import com.destroystokyo.paper.profile.PlayerProfile;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckForNull;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * A class containing utilities for running actions on the Player.
  */
 public class PlayerUtil {
+    private static final Map<UUID, PlayerProfile> profileCache = new HashMap<>();
+
+    /**
+     * Caches a PlayerProfile.
+     * @param uuid The UUID the PlayerProfile belongs to.
+     * @param playerProfile The PlayerProfile to cache.
+     */
+    public static void cachePlayerProfile(@NotNull UUID uuid, @NotNull PlayerProfile playerProfile) {
+        profileCache.put(uuid, playerProfile);
+    }
+
+    /**
+     * Removes a PlayerProfile from the cache.
+     * @param uuid The UUID the PlayerProfile belongs to.
+     */
+    public static void removeCachedPlayerProfile(UUID uuid) {
+        profileCache.remove(uuid);
+    }
+
+    /**
+     * Removes all PlayerProfiles from the cache.
+     */
+    public static void clearCachedPlayerProfiles() {
+        profileCache.clear();
+    }
+
+    /**
+     * Gets the PlayerProfile from the cache or null if there is no PlayerProfile cached for the given UUID.
+     * @param uuid The UUID to retrieve the PlayerProfile for.
+     * @return A PlayerProfile or null.
+     */
+    @CheckForNull
+    public static PlayerProfile getCachedPlayerProfile(UUID uuid) {
+        return profileCache.get(uuid);
+    }
+
     /**
      * Attempts to add an ItemStack to the player's inventory and if it can't, it will instead drop it at the player's feet.
      * @param player A Bukkit Player

--- a/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
@@ -68,7 +68,6 @@ public class PlayerUtil {
             addStack.setAmount(amount);
 
             giveItem(inventory, addStack, location);
-            // appropriate
         }
     }
 
@@ -80,12 +79,9 @@ public class PlayerUtil {
      * @param location The location to drop items if the inventory is full.
      */
     private static void giveItem(Inventory inventory, ItemStack addStack, Location location) {
-        // Try to add the item stack to the inventory
         HashMap<Integer, ItemStack> leftover = inventory.addItem(addStack);
 
-        // If there are leftover items, we need to handle them
         if (!leftover.isEmpty()) {
-            // Drop the leftover items on the ground
             for (ItemStack item : leftover.values()) {
                 if (item.getAmount() > 0) {
                     dropItem(location.getWorld(), location, item);

--- a/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
@@ -1,7 +1,11 @@
 package com.github.lukesky19.skylib.player;
 
 import com.destroystokyo.paper.profile.PlayerProfile;
-import org.bukkit.entity.Player;
+import com.github.lukesky19.skylib.version.VersionUtil;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,30 +55,89 @@ public class PlayerUtil {
     }
 
     /**
-     * Attempts to add an ItemStack to the player's inventory and if it can't, it will instead drop it at the player's feet.
-     * @param player A Bukkit Player
-     * @param itemStack A Bukkit ItemStack
-     * @param amount The amount of items to give
+     * Gives an item to a player and drops any items that can't be added on the ground.
+     * @param inventory The Inventory to add the ItemStack to.
+     * @param addStack The ItemStack to add.
+     * @param amount The amount of items to add.
+     * @param location The location to drop any items that don't fit inside the inventory.
      */
-    public static void giveItem(@NotNull Player player, @NotNull ItemStack itemStack, int amount) {
-        if(amount > itemStack.getMaxStackSize()) {
-            int count = amount / itemStack.getMaxStackSize();
-            itemStack.setAmount(itemStack.getMaxStackSize());
+    public static void giveItem(Inventory inventory, ItemStack addStack, int amount, Location location) {
+        if(VersionUtil.getMajorVersion() >= 21 && VersionUtil.getMinorVersion() < 3) {
+            giveItem1_21(inventory, addStack, amount, location);
+        } else {
+            addStack.setAmount(amount);
 
-            for(int i = 1; i <= count; i++) {
-                HashMap<Integer, ItemStack> leftover = player.getInventory().addItem(itemStack);
-                for(Map.Entry<Integer, ItemStack> leftoverEntry : leftover.entrySet()) {
-                    ItemStack leftoverStack = leftoverEntry.getValue();
-                    player.getWorld().dropItem(player.getLocation(), leftoverStack);
+            giveItem(inventory, addStack, location);
+            // appropriate
+        }
+    }
+
+    /**
+     * Gives an item to a player and drops any items that can't be added on the ground.
+     * This works for all versions except 1.21 and 1.21.1 due to a bug in the API that is fixed in 1.21.3 and newer.
+     * @param inventory The Inventory to add the item to.
+     * @param addStack The ItemStack to add.
+     * @param location The location to drop items if the inventory is full.
+     */
+    private static void giveItem(Inventory inventory, ItemStack addStack, Location location) {
+        // Try to add the item stack to the inventory
+        HashMap<Integer, ItemStack> leftover = inventory.addItem(addStack);
+
+        // If there are leftover items, we need to handle them
+        if (!leftover.isEmpty()) {
+            // Drop the leftover items on the ground
+            for (ItemStack item : leftover.values()) {
+                if (item.getAmount() > 0) {
+                    dropItem(location.getWorld(), location, item);
                 }
             }
-        } else {
-            itemStack.setAmount(amount);
-            HashMap<Integer, ItemStack> leftover = player.getInventory().addItem(itemStack);
-            for(Map.Entry<Integer, ItemStack> leftoverEntry : leftover.entrySet()) {
-                ItemStack leftoverStack = leftoverEntry.getValue();
-                player.getWorld().dropItem(player.getLocation(), leftoverStack);
+        }
+    }
+
+    /**
+     * Gives an item to a player.
+     * This handles stack sizes because of a bug in the api for versions 1.21 and 1.21.1 with the new stack size component.
+     * @param inventory The Inventory to add items to.
+     * @param itemStack The ItemStack to add.
+     * @param amount The amount of items to add.
+     * @param location The location to drop items if the inventory is full.
+     */
+    private static void giveItem1_21(@NotNull Inventory inventory, @NotNull ItemStack itemStack, int amount, Location location) {
+        int maxStackSize = itemStack.getMaxStackSize();
+        int remainder = amount % maxStackSize;
+        int stacks = (amount - remainder) / maxStackSize;
+
+        if(stacks == 0 && remainder == 0) return;
+
+        if(stacks >= 1) {
+            final ItemStack addStack = itemStack.clone();
+            addStack.setAmount(maxStackSize);
+
+            for(int i = 1; i <= stacks; i++) {
+                giveItem(inventory, addStack, location);
             }
+        }
+
+        if(remainder >= 1) {
+            final ItemStack addStack = itemStack.clone();
+            addStack.setAmount(remainder);
+
+            for(int i = 1; i <= stacks; i++) {
+                giveItem(inventory, addStack, location);
+            }
+        }
+    }
+
+    /**
+     * Drops an item stack at the specified location.
+     * @param world    The world where the item will be dropped.
+     * @param location The location where the item will be dropped.
+     * @param itemStack The item stack to drop.
+     */
+    private static void dropItem(World world, Location location, ItemStack itemStack) {
+        if (world != null && location != null && itemStack != null && itemStack.getAmount() > 0) {
+            Item item = world.dropItem(location, itemStack);
+            item.setPickupDelay(0); // Optional: Set pickup delay to 0 so players can pick it up immediately
         }
     }
 }

--- a/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/player/PlayerUtil.java
@@ -17,7 +17,7 @@ public class PlayerUtil {
      * @param itemStack A Bukkit ItemStack
      * @param amount The amount of items to give
      */
-    public static void giveItem(@NotNull Player player, @NotNull ItemStack itemStack, @NotNull int amount) {
+    public static void giveItem(@NotNull Player player, @NotNull ItemStack itemStack, int amount) {
         if(amount > itemStack.getMaxStackSize()) {
             int count = amount / itemStack.getMaxStackSize();
             itemStack.setAmount(itemStack.getMaxStackSize());

--- a/src/main/java/com/github/lukesky19/skylib/record/Time.java
+++ b/src/main/java/com/github/lukesky19/skylib/record/Time.java
@@ -1,0 +1,11 @@
+package com.github.lukesky19.skylib.record;
+
+public record Time(
+        int years,
+        int months,
+        int weeks,
+        int days,
+        int hours,
+        int minutes,
+        int seconds,
+        int milliseconds) {}

--- a/src/main/java/com/github/lukesky19/skylib/version/VersionUtil.java
+++ b/src/main/java/com/github/lukesky19/skylib/version/VersionUtil.java
@@ -1,0 +1,60 @@
+package com.github.lukesky19.skylib.version;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Class that contains data about the server's Minecraft Version.
+ */
+public class VersionUtil {
+    private static String minecraftVersion;
+    private static int majorVersion;
+    private static int minorVersion;
+
+    /**
+     * Get the Minecraft version the server is running. I.e., 1.21.3.
+     * @return The server's Minecraft version.
+     */
+    public static String getMinecraftVersion() {
+        return minecraftVersion;
+    }
+
+    /**
+     * Gets the major version of the Minecraft version. I.e., 21 in 1.21.3.
+     * @return The server's major version of the Minecraft version.
+     */
+    public static int getMajorVersion() {
+        return majorVersion;
+    }
+
+    /**
+     * Gets the minor version of the Minecraft version. I.e., 3 in 1.21.3.
+     * @return The server's minor version of the Minecraft version.
+     */
+    public static int getMinorVersion() {
+        return minorVersion;
+    }
+
+    /**
+     * Sets the Minecraft version the server is running.
+     * @param minecraftVersion The server's Minecraft version.
+     */
+    public static void setMinecraftVersion(@NotNull String minecraftVersion) {
+        VersionUtil.minecraftVersion = minecraftVersion;
+    }
+
+    /**
+     * Sets the major version of the Minecraft version.
+     * @param majorVersion The server's major Minecraft version. I.e., 21 in 1.21.3.
+     */
+    public static void setMajorVersion(int majorVersion) {
+        VersionUtil.majorVersion = majorVersion;
+    }
+
+    /**
+     * Sets the minor version of the Minecraft version.
+     * @param minorVersion The server's minor Minecraft version. I.e., 3 in 1.21.3.
+     */
+    public static void setMinorVersion(int minorVersion) {
+        VersionUtil.minorVersion = minorVersion;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SkyLib
-version: '1.0.0'
+version: '${version}'
 main: com.github.lukesky19.skylib.SkyLib
 api-version: '1.21'
 depend: [PlaceholderAPI]


### PR DESCRIPTION
* Add VersionUtil containing data about the server's Minecraft version.
* Update the Inventory GUI API with options to set ItemFlags and ItemModels on 1.21.3 and newer.
* Fix the version in plugin.yml not using the version defined in build.gradle.kts.
* Add option for setting a PlayerSkull's skin using a PlayerProfile.
* Remove @NotNull annotation on primitive int. 
* Add a PlayerProfile cache.
* Improve the giveItem method and fix an issue with partial stack sizes. 
* Remove leftover comments.
* Fix oversized stack issue in 1.21 and 1.21.1.
* Add methods to convert milliseconds to individual units of time contained in the Time record and back. 
* Removed the millisToString method.
* Fix InventoryGUI#createInventory not setting the inventory variable with the created Inventory.
* Update README.md and add missing Javadoc.
